### PR TITLE
Experimental approach to magic constants with ReflectionClass

### DIFF
--- a/src/abstract-plugin.php
+++ b/src/abstract-plugin.php
@@ -248,8 +248,8 @@ abstract class Abstract_Plugin {
 	protected function configure_defaults() {
 		$this->modules        = new \stdClass();
 		$this->modules->count = 0;
-		$this->installed_dir  = static::dirname( static::$current_file, 1 );
-		$this->plugin_basedir = static::dirname( static::$current_file, 2 );
+		$this->installed_dir  = static::dirname( static::current_file(), 1 );
+		$this->plugin_basedir = static::dirname( static::current_file(), 2 );
 		$assumed_plugin_name  = basename( $this->plugin_basedir );
 		$this->plugin_file    = $this->plugin_basedir . '/' . $assumed_plugin_name . '.php';
 		$this->wp_plugin_slug = $assumed_plugin_name . '/' . $assumed_plugin_name . '.php';
@@ -267,7 +267,7 @@ abstract class Abstract_Plugin {
 				$this->version = $this->plugin_data['Version'];
 			}
 		} else {
-			$this->installed_url = plugins_url( '/', static::$current_file );
+			$this->installed_url = plugins_url( '/', static::current_file() );
 		}
 		// Setup network url and fallback in case siteurl is not defined.
 		if ( ! defined( 'WP_NETWORKURL' ) && is_multisite() ) {
@@ -276,6 +276,28 @@ abstract class Abstract_Plugin {
 			define( 'WP_NETWORKURL', get_site_url() );
 		}
 		$this->network_url = WP_NETWORKURL;
+	}
+
+	/**
+	 * Returns the namespace of the caller class (typically a child class)
+	 *
+	 * @return string
+	 */
+	protected static function autoload_class_prefix() {
+		$ref = new \ReflectionClass(static::class);
+
+		return $ref->getNamespaceName();
+	}
+
+	/**
+	 * Returns the file name of the caller class (typically a child class)
+	 *
+	 * @return string
+	 */
+	protected static function current_file() {
+		$ref = new \ReflectionClass(static::class);
+
+		return $ref->getFileName();
 	}
 
 	/**
@@ -417,7 +439,7 @@ abstract class Abstract_Plugin {
 		if ( stristr( $class, '\\' ) ) {
 
 			// If the first item is == the collection name, trim it off.
-			$class = str_ireplace( static::$autoload_class_prefix, '', $class );
+			$class = str_ireplace( static::autoload_class_prefix(), '', $class );
 
 			// Maybe fix formatting underscores to dashes and double to single slashes.
 			$class     = str_replace( [ '_', '\\' ], [ '-', '/' ], $class );


### PR DESCRIPTION
This is a small POC that reduces a bit of code duplication with PHP's Reflections API.

Currently, each class that extends the abstract plugin class needs to redefine the `$current_file` and `$autoload_class_prefix` static properties. This is because `__NAMESPACE__` and `__FILE__` are evaluated at compile time for the file they are located in, not the caller.

By using `ReflectionClass` you can get the namespace and file path for the _caller_ class, and access the values via static methods:

```php
echo static::autoload_class_prefix(); // My\Caller\Namespace
echo static::current_file(); // /path/to/class-caller.php
```

This is functional but should be considered a POC; in PHP < 7, Reflection and Static methods had a small performance hit. I believe PHP > 7 has improved this dramatically (my understanding is that static methods are now _faster_ than non-static) but an xdebug profile would help verify that the hit, if any, is negligible.

cc @scarstens 