### PR TITLE
Add control structure spacing rule

### DIFF
--- a/.circleci/phpcs.xml
+++ b/.circleci/phpcs.xml
@@ -37,4 +37,11 @@
 		<exclude-pattern>/lib/*</exclude-pattern>
 		<exclude-pattern>/src/*</exclude-pattern>
 	</rule>
+
+	<!-- Prevent empty lines at the start or end of control structures. -->
+	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
+		<properties>
+			<property name="blank_line_check" value="true" />
+		</properties>
+	</rule>
 </ruleset>

--- a/src/abstract-plugin.php
+++ b/src/abstract-plugin.php
@@ -194,7 +194,6 @@ abstract class Abstract_Plugin {
 
 		// Hook can be used by mu plugins to modify plugin behavior after plugin is setup.
 		do_action( $this->wp_hook_pre . '_setup', $this );
-
 	} // END public function __construct
 
 	/**
@@ -228,6 +227,7 @@ abstract class Abstract_Plugin {
 		$intersect            = array_intersect_assoc( $parent, $class_array );
 		$intersect_depth      = count( $intersect );
 		$autoload_match_depth = static::$autoload_ns_match_depth;
+
 		// Confirm $class is in same namespace as this autoloader.
 		if ( $intersect_depth >= $autoload_match_depth ) {
 			$file = $this->get_file_name_from_class( $class );
@@ -239,7 +239,6 @@ abstract class Abstract_Plugin {
 				$this->load_file( $this->installed_dir . $file );
 			}
 		}
-
 	}
 
 	/**
@@ -363,10 +362,9 @@ abstract class Abstract_Plugin {
 			$class_filename      = str_replace( '_', '-', $class_filename );
 
 			return static::$filename_prefix . $class_filename . '.php';
-		} else {
-
-			return $this->psr4_get_file_name_from_class( $class );
 		}
+
+		return $this->psr4_get_file_name_from_class( $class );
 	}
 
 	/**


### PR DESCRIPTION
Adds the `WordPress.WhiteSpace.ControlStructureSpacing` rule to the ruleset, to resolve some downstream linting issues.